### PR TITLE
Add tiplabels and other plot.phylo functions

### DIFF
--- a/R/plot_ClaDS_phylo.R
+++ b/R/plot_ClaDS_phylo.R
@@ -1,11 +1,11 @@
 
-plot_ClaDS_phylo=function(phylo,rates,rates2=NULL,same.scale=T,main=NULL,lwd=2,log=T){
+plot_ClaDS_phylo=function(phylo, rates, rates2=NULL, same.scale=TRUE, main=NULL, lwd=2, log=TRUE, show.tip.label=FALSE, ...){
   Colors = colorRampPalette(c("steelblue2","paleturquoise3","palegreen2","yellow2","salmon1","darkorange", "red","red4"))( 100 ) 
   if(is.null(rates2)){
     if(log) rates=log(rates)
     if(isTRUE(all.equal(rep(as.numeric(rates[1]),length(rates)),as.numeric(rates)))){
       col=rep(1,length(rates))
-      plot(phylo, edge.color = Colors[col], show.tip.label = F,main=main,edge.width =lwd)
+      plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
       if(log){
         image.plot(z = c(exp(rates[1]),2*exp(rates[1])),col = Colors, horizontal=T,legend.only = T)
       }else{
@@ -13,7 +13,7 @@ plot_ClaDS_phylo=function(phylo,rates,rates2=NULL,same.scale=T,main=NULL,lwd=2,l
       }
     }else{
       col = round( (rates - min(rates)) / diff(range(rates))*99   )+1
-      plot(phylo, edge.color = Colors[col], show.tip.label = F,main=main,edge.width =lwd)
+      plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
       if(log){
         min=min(rates)
         max=max(rates)
@@ -42,9 +42,9 @@ plot_ClaDS_phylo=function(phylo,rates,rates2=NULL,same.scale=T,main=NULL,lwd=2,l
       max=max(max(rates),max(rates2))
       par(mfrow=c(1,2))
       col = round(( (rates - min) / (max-min))*99   )+1
-      plot(phylo, edge.color = Colors[col], show.tip.label = F,edge.width =lwd)
+      plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
       col = round(( (rates2 - min) / (max-min))*99   )+1
-      plot(phylo, edge.color = Colors[col], show.tip.label = F,edge.width =lwd)
+      plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
       par(mfrow=c(1,1))
       if(log){
         m10=floor(min/log(10))
@@ -66,7 +66,7 @@ plot_ClaDS_phylo=function(phylo,rates,rates2=NULL,same.scale=T,main=NULL,lwd=2,l
       par(mfrow=c(1,2))
       if(isTRUE(all.equal(rep(rates[1],length(rates)),rates))){
         col=rep(1,length(rates))
-        plot(phylo, edge.color = Colors[col], show.tip.label = F,edge.width =lwd)
+        plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
         if(log){
           
           image.plot(z = c(exp(rates[1]),2*exp(rates[1])),col = Colors, horizontal=T,legend.only = T)
@@ -75,7 +75,7 @@ plot_ClaDS_phylo=function(phylo,rates,rates2=NULL,same.scale=T,main=NULL,lwd=2,l
         }
       }else{
         col = round(( (rates - min(rates)) / (max(rates)-min(rates)))*99   )+1
-        plot(phylo, edge.color = Colors[col], show.tip.label = F,edge.width =lwd)
+        plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
         if(log){
           min=min(rates)
           max=max(rates)
@@ -96,7 +96,7 @@ plot_ClaDS_phylo=function(phylo,rates,rates2=NULL,same.scale=T,main=NULL,lwd=2,l
       }
       if(isTRUE(all.equal(rep(rates2[1],length(rates2)),rates2))){
         col=rep(1,length(rates2))
-        plot(phylo, edge.color = Colors[col], show.tip.label = F,edge.width =lwd)
+        plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
         if(log){
           image.plot(z = c(exp(rates2[1]),2*exp(rates2[1])),col = Colors, horizontal=T,legend.only = T)
         }else{
@@ -104,7 +104,7 @@ plot_ClaDS_phylo=function(phylo,rates,rates2=NULL,same.scale=T,main=NULL,lwd=2,l
         }
       }else{
         col = round(( (rates2 - min(rates2)) / (max(rates2)-min(rates2)))*99   )+1
-        plot(phylo, edge.color = Colors[col], show.tip.label = F,edge.width =lwd)
+        plot(phylo, edge.color = Colors[col], show.tip.label = show.tip.label, main=main, edge.width = lwd, ...)
         if(log){
           min=min(rates2)
           max=max(rates2)

--- a/man/plot_ClaDS_phylo.Rd
+++ b/man/plot_ClaDS_phylo.Rd
@@ -8,7 +8,7 @@ Plot a phylogeny with branches colored according to branch-specific rate values
 }
 \usage{
 plot_ClaDS_phylo(phylo, rates, rates2 = NULL, 
-                same.scale = T, main = NULL, lwd = 2, log = T)
+                same.scale = TRUE, main = NULL, lwd = 2, log = TRUE, show.tip.label = FALSE, ...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -19,6 +19,8 @@ plot_ClaDS_phylo(phylo, rates, rates2 = NULL,
   \item{main}{A title for the plot.}
   \item{lwd}{Width of the tree branch lengths. Default to 2.}
   \item{log}{A boolean specifying whether the rates values are plotted on a log scale. Default to TRUE.}
+  \item{show.tip.label}{A boolean specifying whether to plot tip labels. Default to FALSE.}
+  \item{...}{other optional arguments to be passed to \code{\link{plot.phylo}.}}
 }
 \references{
 Maliet O., Hartig F. and Morlon H. 2019, A model with many small shifts for estimating species-specific diversificaton rates, \emph{Nature Ecology and Evolution}, doi 10.1038/s41559-019-0908-0


### PR DESCRIPTION
This patch makes show.tip.labels default to FALSE, but allows it to be overridden by users, and allows users to pass other commands to plot.phylo (e.g. if they want a fan tree or something:

> plot_ClaDS_phylo(tree, MAPS[-(1:3)])   # as before

> plot_ClaDS_phylo(tree, MAPS[-(1:3)], type="f")  # fan tree please!

> plot_ClaDS_phylo(tree, MAPS[-(1:3)], type="f", show.tip.label=T)  # tiplabels on a fan tree