### PR TITLE
Use modern Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,4 @@
-# There is no R support.  Use a fake language
-language: c
-env:
-  global:
-    - R_LIBS_USER=~/R
-before_install:
-#  We want R 3.0 packages, official Travis images only provide 2.14
-  - sudo add-apt-repository "deb http://cran.rstudio.com/bin/linux/ubuntu $(lsb_release -cs)/"
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-  - sudo apt-get update
-  - sudo apt-get install r-base-dev r-recommended qpdf
-  - test -d $R_LIBS_USER || mkdir $R_LIBS_USER
-install:
-  - R --version
-  - R -e '.libPaths(); sessionInfo()'
-#  CRAN packages required by RPANDA
-  - grep ^Imports DESCRIPTION | sed -e 's/Imports. //' -e 's/,/ /g' -e 's/$//' | xargs Rscript -e  'install.packages(append(commandArgs(TRUE), "picante"), dep = TRUE, repos = c("http://cran.rstudio.com", "http://cran.r-project.org"))'
-#  CRAN packages required by RPANDA tests
-  - Rscript -e 'install.packages(c("testthat", "vegan", "permute", "lattice", "nlme"), dep = TRUE, repos = c("http://cran.rstudio.com", "http://cran.r-project.org"))'
-script:
-  - R CMD build --no-manual .
-  - R CMD INSTALL *gz
-  - cd tests && Rscript -e 'library(methods);library(testthat);library(RPANDA); test_check("RPANDA")'
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
+language: R
+cache: packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: R
 cache: packages
 
 before_install:
+  # ImageMagick
+  - sudo add-apt-repository -y ppa:opencpu/imagemagick
+  - sudo apt-get update
+  - sudo apt-get install -y libmagick++-dev
   # MPFR
   - sudo apt install -qq libmpfr-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@
 
 language: R
 cache: packages
+
+before_install:
+  # MPFR
+  - sudo apt install -qq libmpfr-dev
+


### PR DESCRIPTION
Hi RPANDA maintainers,

I see that on the branches I've checked, the Travis CI build fails. Taking a look at the `.travis.yml` file, I see it's script written before R was supported. Because nowadays, R is supported, a `.travis.yml` file can be written cleaner.

I created it by calling `usethis::use_travis()` and adding the apt repos needed (I peeked at [one of my repos](https://github.com/richelbilderbeek/razzo/blob/master/.travis.yml)).

I hope you'll agree this is a way simpler script :grin: 

Keep up the good work, Richel Bilderbeek