### PR TITLE
Modified sort call to use unlist() on low_z. 

### DIFF
--- a/R/BICompare.R
+++ b/R/BICompare.R
@@ -35,7 +35,7 @@ BICompare <- function(phylo,t,meth=c("ultrametric")){
 					pDP[[j]] <- 1-pnorm(as.numeric(r[j]),m,s)
 				}
 			low_z <- cbind(as.numeric(r),pDP)
-			low_z <- sort(low_z[,1])
+			low_z <- sort(unlist(low_z[,1]))
 	r = low_z[5]			
 	}		
 
@@ -59,7 +59,7 @@ BICompare <- function(phylo,t,meth=c("ultrametric")){
 					pDP[[j]] <- 1-pnorm(as.numeric(r[j]),m,s)
 				}
 			low_z <- cbind(as.numeric(r),pDP)
-			low_z <- sort(low_z[,1])
+			low_z <- sort(unlist(low_z[,1]))
 	r = low_z[50]			
 	}	
 	


### PR DESCRIPTION
Hi, the sort() call in BICompare() was giving an 'x must be atomic for sort.int' error. (Quote might not be exact but hopefully you get the idea.)

